### PR TITLE
Update shadcn-svelte maintainer status

### DIFF
--- a/sites/www/src/lib/info/open-source.ts
+++ b/sites/www/src/lib/info/open-source.ts
@@ -4,7 +4,8 @@ const openSource: Project[] = [
 	{
 		name: 'shadcn-svelte',
 		description: 'A Svelte port of shadcn/ui.',
-		link: 'https://shadcn-svelte.com'
+		link: 'https://shadcn-svelte.com',
+		status: 'maintainer'
 	}
 ];
 

--- a/sites/www/src/lib/info/types.ts
+++ b/sites/www/src/lib/info/types.ts
@@ -5,4 +5,5 @@ export type Project = {
 	description: string;
 	link: string;
 	Logo?: Component;
+	status?: 'maintainer' | 'contributor';
 };

--- a/sites/www/src/routes/+page.svelte
+++ b/sites/www/src/routes/+page.svelte
@@ -49,7 +49,18 @@
 				</ul>
 			</div>
 			<div class="flex flex-col gap-2">
-				<p>A few of the things I contribute to:</p>
+				<p>
+					{(() => {
+						const hasMaintainer = openSource.some((p) => p.status === 'maintainer');
+						const hasContributor = openSource.some((p) => !p.status || p.status === 'contributor');
+						if (hasMaintainer && hasContributor) {
+							return 'A few of the things I maintain and contribute to:';
+						}
+						return hasMaintainer
+							? 'A few of the things I maintain:'
+							: 'A few of the things I contribute to:';
+					})()}
+				</p>
 				<ul>
 					{#each openSource as project, i (i)}
 						<li>


### PR DESCRIPTION
Set shadcn-svelte's status to 'maintainer' and update the open-source projects display to reflect contributor/maintainer roles.

---
<a href="https://cursor.com/background-agent?bcId=bc-333b3b5d-4410-4397-b5eb-cd13929a5718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-333b3b5d-4410-4397-b5eb-cd13929a5718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

